### PR TITLE
[misc] expose merge function in a separate module

### DIFF
--- a/Settings.js
+++ b/Settings.js
@@ -2,17 +2,7 @@ let defaults, possibleConfigFiles, settingsExist;
 const fs = require("fs");
 const path = require("path");
 const env = (process.env.NODE_ENV || "development").toLowerCase();
-
-const merge = function(settings, defaults) {
-	for (const [key, value] of Object.entries(settings)) {
-		if ((typeof(value) === "object") && !(value instanceof Array)) {
-			defaults[key] = merge(value, defaults[key] || {});
-		} else {
-			defaults[key] = value;
-		}
-	}
-	return defaults;
-};
+const { merge } = require('./merge');
 
 const defaultSettingsPath = path.normalize(__dirname + "/../../config/settings.defaults");
 

--- a/merge.js
+++ b/merge.js
@@ -1,0 +1,12 @@
+function merge(settings, defaults) {
+  for (const [key, value] of Object.entries(settings)) {
+    if ((typeof(value) === "object") && !(value instanceof Array)) {
+      defaults[key] = merge(value, defaults[key] || {});
+    } else {
+      defaults[key] = value;
+    }
+  }
+  return defaults;
+}
+
+module.exports = { merge };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overleaf/settings",
   "description": "A centralised settings system for Overleaf",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "repository": "overleaf/settings-module"
 }


### PR DESCRIPTION
For https://github.com/overleaf/issues/issues/3225

This PR is adding a new module `@overleaf/settings/merge` for re-using the same merge function in chained settings files (google-ops->saas->defaults / tests->saas->defaults).
