### PR TITLE
[misc] fix path to app config/ dir following the renaming of the package

### DIFF
--- a/Settings.js
+++ b/Settings.js
@@ -4,7 +4,7 @@ const path = require("path");
 const env = (process.env.NODE_ENV || "development").toLowerCase();
 const { merge } = require('./merge');
 
-const defaultSettingsPath = path.normalize(__dirname + "/../../config/settings.defaults");
+const defaultSettingsPath = path.normalize(__dirname + "/../../../config/settings.defaults");
 
 if (fs.existsSync(`${defaultSettingsPath}.js`)) {
 	console.log(`Using default settings from ${defaultSettingsPath}.js`);
@@ -23,10 +23,10 @@ if (process.env.SHARELATEX_CONFIG) {
 } else {
 	possibleConfigFiles = [
 		process.cwd() + `/config/settings.${env}.js`,
-		path.normalize(__dirname + `/../../config/settings.${env}.js`),
+		path.normalize(__dirname + `/../../../config/settings.${env}.js`),
 		// TODO: remove these in the next major version
 		process.cwd() + `/config/settings.${env}.coffee`,
-		path.normalize(__dirname + `/../../config/settings.${env}.coffee`)
+		path.normalize(__dirname + `/../../../config/settings.${env}.coffee`)
 	];
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overleaf/settings",
   "description": "A centralised settings system for Overleaf",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "repository": "overleaf/settings-module"
 }


### PR DESCRIPTION
For https://github.com/overleaf/issues/issues/3238

The Settings.js file is now located in node_modules/@overleaf/settings,
 which is one level deeper than node_modules/settings-sharelatex.